### PR TITLE
my README file caused 'unused template' error

### DIFF
--- a/jobs/awslogs/spec
+++ b/jobs/awslogs/spec
@@ -3,7 +3,6 @@ name: awslogs
 templates:
   config/awslogs.conf.erb: config/awslogs.conf
   config/awscli.conf.erb: config/awscli.conf
-  config/config/README: config/config/README
   bin/awslogsd.sh.erb: bin/awslogsd.sh
   config/proxy.conf.erb: config/proxy.conf
   bin/ctl: bin/ctl

--- a/jobs/awslogs/spec
+++ b/jobs/awslogs/spec
@@ -3,6 +3,7 @@ name: awslogs
 templates:
   config/awslogs.conf.erb: config/awslogs.conf
   config/awscli.conf.erb: config/awscli.conf
+  config/config/README: config/config/README
   bin/awslogsd.sh.erb: bin/awslogsd.sh
   config/proxy.conf.erb: config/proxy.conf
   bin/ctl: bin/ctl

--- a/jobs/awslogs/templates/config/config/README
+++ b/jobs/awslogs/templates/config/config/README
@@ -1,1 +1,0 @@
-# a place for additional config files as specified in awslogsd.sh


### PR DESCRIPTION
https://ci.fr.cloud.gov/teams/main/pipelines/awslogs-boshrelease/jobs/awslogs-boshrelease/builds/7

"There are unused template files for job 'awslogs': config/config/README"

so added to spec file
