### PR TITLE
Send a TERM signal to all aws logs processes

### DIFF
--- a/jobs/awslogs/templates/bin/ctl
+++ b/jobs/awslogs/templates/bin/ctl
@@ -25,6 +25,9 @@ case $1 in
   stop)
     kill_and_wait $PIDFILE
 
+    # ensure all child process are really dead
+    pkill -f "aws logs push"
+
     ;;
   *)
     echo "Usage: awslogs_ctl {start|stop}"


### PR DESCRIPTION
This is a gross but I'm tired of it failing